### PR TITLE
Add unified identifier support in lexer

### DIFF
--- a/parser/src/lexer.rs
+++ b/parser/src/lexer.rs
@@ -360,11 +360,11 @@ impl<'a> Lexer<'a> {
 		self.head += count;
 	}
 
-	pub fn parse_identifier(
-		&mut self,
-		location: &'static str,
-		check_reserved: bool,
-	) -> Result<&'a str, ParseError> {
+        pub fn parse_identifier(
+                &mut self,
+                location: &'static str,
+                check_reserved: bool,
+        ) -> Result<&'a str, ParseError> {
 		enum State {
 			Standard,
 			StartOfUnicode,
@@ -487,13 +487,25 @@ impl<'a> Lexer<'a> {
 		// If left over
 		let is_invalid =
 			check_reserved && !crate::lexer::utilities::is_valid_variable_identifier(current);
-		if is_invalid {
-			Err(ParseError::new(ParseErrors::ReservedIdentifier, start.with_length(current.len())))
-		} else {
-			self.head += current.len() as u32;
-			Ok(current)
-		}
-	}
+                if is_invalid {
+                        Err(ParseError::new(ParseErrors::ReservedIdentifier, start.with_length(current.len())))
+                } else {
+                        self.head += current.len() as u32;
+                        Ok(current)
+                }
+        }
+
+        /// Parse an identifier and immediately convert it into a [`UnifiedIdentifier`].
+        /// This is useful for identifiers where stylistic differences should be ignored
+        /// such as type names or object property keys.
+        pub fn parse_unified_identifier(
+                &mut self,
+                location: &'static str,
+                check_reserved: bool,
+        ) -> Result<crate::types::unified_identifier::UnifiedIdentifier, ParseError> {
+                let ident = self.parse_identifier(location, check_reserved)?;
+                Ok(crate::types::unified_identifier::UnifiedIdentifier::new(ident))
+        }
 
 	// Will append the length on `until`
 	pub fn parse_until(&mut self, until: &str) -> Result<&'a str, ()> {

--- a/parser/src/types/unified_identifier.rs
+++ b/parser/src/types/unified_identifier.rs
@@ -1,4 +1,6 @@
-#[derive(Debug)]
+#[derive(Debug, Clone, Eq)]
+#[cfg_attr(feature = "serde-serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "self-rust-tokenize", derive(self_rust_tokenize::SelfRustTokenize))]
 pub struct UnifiedIdentifier {
     original: String,        // Original spelling (kept for debugging/round‑tripping)
     normalized: Vec<String>, // Lower‑case words after unification
@@ -123,6 +125,12 @@ impl UnifiedIdentifier {
             original: original.to_owned(),
             normalized: normalize(original),
         }
+    }
+
+    /// Returns the identifier exactly as it appeared in the source code.
+    #[must_use]
+    pub fn original(&self) -> &str {
+        &self.original
     }
 }
 


### PR DESCRIPTION
## Summary
- derive common traits for `UnifiedIdentifier`
- add a helper on `UnifiedIdentifier` to get the original text
- add `Lexer::parse_unified_identifier` for creating unified identifiers

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68539937beec8328a38ccf1284c6129d