### PR TITLE
Implement Visitable for UnifiedIdentifierBuf

### DIFF
--- a/parser/src/visiting.rs
+++ b/parser/src/visiting.rs
@@ -15,9 +15,10 @@ pub use visitors::*;
 pub use visitors_mut::*;
 
 mod ast {
-	use temporary_annex::Annex;
+        use temporary_annex::Annex;
 
-	use crate::block::{BlockLike, BlockLikeMut};
+        use crate::block::{BlockLike, BlockLikeMut};
+        use unified_identifier::UnifiedIdentifierBuf;
 
 	use super::{
 		BlockItem, BlockItemMut, Chain, Expression, ImmutableVariableOrProperty,

--- a/unified_identifier/src/lib.rs
+++ b/unified_identifier/src/lib.rs
@@ -1,9 +1,8 @@
+//! Unified identifier types – owned (`UnifiedIdentifierBuf`) and borrowed (`UnifiedIdentifier`)
+//! Similar to `PathBuf` / `Path` in the std‑lib, plus *canonical‑name* cache.
 
 #[cfg(feature = "serde-serialize")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-//! Unified identifier types – owned (`UnifiedIdentifierBuf`) and borrowed (`UnifiedIdentifier`)
-//! Similar to `PathBuf` / `Path` in the std‑lib, plus *canonical‑name* cache.
 
 use std::{borrow::Cow, fmt, hash::{Hash, Hasher}, ops::Deref};
 use once_cell::sync::OnceCell;


### PR DESCRIPTION
## Summary
- fix misplaced module docs in `unified_identifier`
- import `UnifiedIdentifierBuf` in visitor module so the `Visitable` impl is recognised

## Testing
- `cargo check --workspace` *(fails: could not compile `ezno-parser`)*

------
https://chatgpt.com/codex/tasks/task_e_6867d169ea90832882df693a57346620