### PR TITLE
Begin converting checker to UnifiedIdentifierBuf

### DIFF
--- a/checker/src/context/environment.rs
+++ b/checker/src/context/environment.rs
@@ -1,5 +1,6 @@
 use source_map::{SourceId, Span, SpanWithSource};
 use std::collections::{HashMap, HashSet};
+use unified_identifier::UnifiedIdentifierBuf;
 
 use crate::{
 	context::{get_on_ctx, information::ReturnState},
@@ -34,7 +35,7 @@ use super::{
 };
 
 /// For WIP contextual access of certain APIs
-pub type ContextLocation = Option<String>;
+pub type ContextLocation = Option<UnifiedIdentifierBuf>;
 
 /// Error type for something already being defined
 pub struct AlreadyExists;
@@ -166,7 +167,7 @@ impl FunctionScope {
 }
 
 /// For labeled statements
-pub type Label = Option<String>;
+pub type Label = Option<UnifiedIdentifierBuf>;
 
 #[derive(Clone, Copy)]
 pub enum Returnable<'a, A: crate::ASTImplementation> {
@@ -1385,13 +1386,13 @@ impl Environment<'_> {
 				.collect()
 		});
 
-		let ty = Type::Interface {
-			name: name.to_owned(),
+                let ty = Type::Interface {
+                        name: UnifiedIdentifierBuf::new(name),
 			parameters,
 			extends: extends.map(|_| TypeId::ANY_TO_INFER_TYPE),
 		};
 		let interface_ty = types.register_type(ty);
-		self.named_types.insert(name.to_owned(), interface_ty);
+                self.named_types.insert(UnifiedIdentifierBuf::new(name), interface_ty);
 		Ok(DeclareInterfaceResult::New(interface_ty))
 	}
 
@@ -1452,9 +1453,9 @@ impl Environment<'_> {
 				.collect()
 		});
 
-		let ty = Type::Class { name: name.to_owned(), type_parameters };
-		let class_type = types.register_type(ty);
-		self.named_types.insert(name.to_owned(), class_type);
+                let ty = Type::Class { name: UnifiedIdentifierBuf::new(name), type_parameters };
+                let class_type = types.register_type(ty);
+                self.named_types.insert(UnifiedIdentifierBuf::new(name), class_type);
 		// TODO duplicates
 
 		Ok(class_type)
@@ -1481,9 +1482,9 @@ impl Environment<'_> {
 				.collect()
 		});
 
-		let ty = Type::AliasTo { to: TypeId::ANY_TO_INFER_TYPE, name: name.to_owned(), parameters };
-		let alias_ty = types.register_type(ty);
-		let existing_type = self.named_types.insert(name.to_owned(), alias_ty);
+                let ty = Type::AliasTo { to: TypeId::ANY_TO_INFER_TYPE, name: UnifiedIdentifierBuf::new(name), parameters };
+                let alias_ty = types.register_type(ty);
+                let existing_type = self.named_types.insert(UnifiedIdentifierBuf::new(name), alias_ty);
 
 		if existing_type.is_none() {
 			Ok(alias_ty)

--- a/checker/src/context/mod.rs
+++ b/checker/src/context/mod.rs
@@ -33,6 +33,7 @@ use self::environment::{DynamicBoundaryKind, FunctionScope};
 pub use environment::Scope;
 pub(crate) use environment::Syntax;
 pub use information::{InformationChain, LocalInformation};
+use unified_identifier::UnifiedIdentifierBuf;
 
 use std::{
 	collections::{
@@ -143,11 +144,11 @@ impl<'a> From<&'a Environment<'a>> for GeneralContext<'a> {
 }
 
 pub struct Names {
-	pub(crate) variables: HashMap<String, VariableOrImport>,
-	pub(crate) named_types: HashMap<String, TypeId>,
+        pub(crate) variables: HashMap<UnifiedIdentifierBuf, VariableOrImport>,
+        pub(crate) named_types: HashMap<UnifiedIdentifierBuf, TypeId>,
 
 	/// For debugging only
-	pub(crate) variable_names: HashMap<VariableId, String>,
+        pub(crate) variable_names: HashMap<VariableId, UnifiedIdentifierBuf>,
 }
 
 #[derive(Debug)]
@@ -156,11 +157,11 @@ pub struct Context<T: ContextType> {
 	pub context_id: ContextId,
 	pub(crate) context_type: T,
 
-	pub(crate) variables: HashMap<String, VariableOrImport>,
-	pub(crate) named_types: HashMap<String, TypeId>,
+        pub(crate) variables: HashMap<UnifiedIdentifierBuf, VariableOrImport>,
+        pub(crate) named_types: HashMap<UnifiedIdentifierBuf, TypeId>,
 
 	/// For debugging AND noting what contexts contain what variables
-	pub(crate) variable_names: HashMap<VariableId, String>,
+        pub(crate) variable_names: HashMap<VariableId, UnifiedIdentifierBuf>,
 
 	/// TODO unsure if needed
 	pub(crate) deferred_function_constraints: HashMap<FunctionId, (FunctionType, SpanWithSource)>,
@@ -219,7 +220,7 @@ impl<T: ContextType> Context<T> {
 			allow_reregistration,
 		};
 
-		let entry = self.variables.entry(name.to_owned());
+                let entry = self.variables.entry(UnifiedIdentifierBuf::new(name));
 		let existing_that_can_be_rewritten = match entry {
 			Entry::Occupied(e) => match e.get() {
 				VariableOrImport::Variable { allow_reregistration, .. } => !*allow_reregistration,
@@ -227,8 +228,8 @@ impl<T: ContextType> Context<T> {
 				| VariableOrImport::ConstantImport { .. } => true,
 			},
 			Entry::Vacant(vacant) => {
-				vacant.insert(variable);
-				self.variable_names.insert(id, name.to_owned());
+                                vacant.insert(variable);
+                                self.variable_names.insert(id, UnifiedIdentifierBuf::new(name));
 				false
 			}
 		};
@@ -240,11 +241,11 @@ impl<T: ContextType> Context<T> {
 			}
 
 			if record_event {
-				self.info.events.push(crate::events::Event::RegisterVariable {
-					name: name.to_owned(),
-					position: declared_at,
-					initial_value,
-				});
+                                self.info.events.push(crate::events::Event::RegisterVariable {
+                                        name: name.to_string(),
+                                        position: declared_at,
+                                        initial_value,
+                                });
 			}
 		}
 
@@ -278,10 +279,10 @@ impl<T: ContextType> Context<T> {
 		let register_variable = self.register_variable(name, declared_at, argument, record_event);
 
 		if let Err(CannotRedeclareVariable { name }) = register_variable {
-			diagnostics_container.add_error(TypeCheckError::CannotRedeclareVariable {
-				name: name.to_owned(),
-				position: declared_at,
-			});
+                                diagnostics_container.add_error(TypeCheckError::CannotRedeclareVariable {
+                                name: name.to_string(),
+                                position: declared_at,
+                        });
 		}
 	}
 
@@ -757,17 +758,17 @@ impl<T: ContextType> Context<T> {
 		default_type: Option<TypeId>,
 		types: &mut TypeStore,
 	) -> crate::types::generics::GenericTypeParameter {
-		let ty = Type::RootPolyType(PolyNature::FunctionGeneric {
-			name: name.to_owned(),
+                let ty = Type::RootPolyType(PolyNature::FunctionGeneric {
+                        name: UnifiedIdentifierBuf::new(name),
 			// TODO this is fixed!!
 			extends: constraint_type.unwrap_or(TypeId::ANY_TYPE),
 		});
 
 		let ty = types.register_type(ty);
-		self.named_types.insert(name.to_owned(), ty);
+                self.named_types.insert(UnifiedIdentifierBuf::new(name), ty);
 
 		crate::types::generics::GenericTypeParameter {
-			name: name.to_owned(),
+                        name: UnifiedIdentifierBuf::new(name),
 			type_id: ty,
 			default: default_type,
 		}
@@ -811,7 +812,7 @@ impl<T: ContextType> Context<T> {
 		declared_at: SpanWithSource,
 		variable_ty: TypeId,
 		types: &mut TypeStore,
-		context: Option<String>,
+                context: Option<UnifiedIdentifierBuf>,
 	) -> Result<TypeId, CannotRedeclareVariable<'a>> {
 		let id = crate::VariableId(declared_at.source, declared_at.start);
 
@@ -822,7 +823,7 @@ impl<T: ContextType> Context<T> {
 			context,
 			allow_reregistration: false,
 		};
-		let entry = self.variables.entry(name.to_owned());
+                let entry = self.variables.entry(UnifiedIdentifierBuf::new(name));
 		if let Entry::Vacant(vacant) = entry {
 			vacant.insert(variable);
 
@@ -838,7 +839,7 @@ impl<T: ContextType> Context<T> {
 			self.info.variable_current_value.insert(id, ty);
 			Ok(ty)
 		} else {
-			Err(CannotRedeclareVariable { name })
+                        Err(CannotRedeclareVariable { name })
 		}
 	}
 

--- a/checker/src/context/root.rs
+++ b/checker/src/context/root.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use source_map::SourceId;
 use std::{collections::HashMap, iter::FromIterator, mem};
+use unified_identifier::UnifiedIdentifierBuf;
 
 pub type RootContext = Context<Root>;
 
@@ -55,38 +56,38 @@ impl RootContext {
 	#[must_use]
 	pub fn new_with_primitive_references() -> Self {
 		// TODO number might not be a reference at some point
-		let named_types = HashMap::from_iter([
-			("number".to_owned(), TypeId::NUMBER_TYPE),
-			("string".to_owned(), TypeId::STRING_TYPE),
-			("boolean".to_owned(), TypeId::BOOLEAN_TYPE),
-			("null".to_owned(), TypeId::NULL_TYPE),
-			("undefined".to_owned(), TypeId::UNDEFINED_TYPE),
-			("void".to_owned(), TypeId::VOID_TYPE),
-			("Array".to_owned(), TypeId::ARRAY_TYPE),
-			("Promise".to_owned(), TypeId::PROMISE_TYPE),
-			("RegExp".to_owned(), TypeId::REGEXP_TYPE),
-			("ImportMeta".to_owned(), TypeId::IMPORT_META),
-			("Function".to_owned(), TypeId::FUNCTION_TYPE),
-			("object".to_owned(), TypeId::OBJECT_TYPE),
-			("Literal".to_owned(), TypeId::LITERAL_RESTRICTION),
-			("Readonly".to_owned(), TypeId::READONLY_RESTRICTION),
-			("Exclusive".to_owned(), TypeId::EXCLUSIVE_RESTRICTION),
-			("Uppercase".to_owned(), TypeId::STRING_UPPERCASE),
-			("Lowercase".to_owned(), TypeId::STRING_LOWERCASE),
-			("Capitalize".to_owned(), TypeId::STRING_CAPITALIZE),
-			("Uncapitalize".to_owned(), TypeId::STRING_UNCAPITALIZE),
-			("NoInfer".to_owned(), TypeId::NO_INFER),
-			("GreaterThan".to_owned(), TypeId::GREATER_THAN),
-			("LessThan".to_owned(), TypeId::LESS_THAN),
-			("MultipleOf".to_owned(), TypeId::MULTIPLE_OF),
-			("NotNotANumber".to_owned(), TypeId::NUMBER_BUT_NOT_NOT_A_NUMBER),
-			("Not".to_owned(), TypeId::NOT_RESTRICTION),
-			("CaseInsensitive".to_owned(), TypeId::CASE_INSENSITIVE),
-			("Infinity".to_owned(), TypeId::INFINITY),
-			("NegativeInfinity".to_owned(), TypeId::NEG_INFINITY),
-			("MinFloat".to_owned(), TypeId::FLOAT_MIN),
-			("MaxFloat".to_owned(), TypeId::FLOAT_MAX),
-		]);
+                let named_types = HashMap::from_iter([
+                        (UnifiedIdentifierBuf::new("number"), TypeId::NUMBER_TYPE),
+                        (UnifiedIdentifierBuf::new("string"), TypeId::STRING_TYPE),
+                        (UnifiedIdentifierBuf::new("boolean"), TypeId::BOOLEAN_TYPE),
+                        (UnifiedIdentifierBuf::new("null"), TypeId::NULL_TYPE),
+                        (UnifiedIdentifierBuf::new("undefined"), TypeId::UNDEFINED_TYPE),
+                        (UnifiedIdentifierBuf::new("void"), TypeId::VOID_TYPE),
+                        (UnifiedIdentifierBuf::new("Array"), TypeId::ARRAY_TYPE),
+                        (UnifiedIdentifierBuf::new("Promise"), TypeId::PROMISE_TYPE),
+                        (UnifiedIdentifierBuf::new("RegExp"), TypeId::REGEXP_TYPE),
+                        (UnifiedIdentifierBuf::new("ImportMeta"), TypeId::IMPORT_META),
+                        (UnifiedIdentifierBuf::new("Function"), TypeId::FUNCTION_TYPE),
+                        (UnifiedIdentifierBuf::new("object"), TypeId::OBJECT_TYPE),
+                        (UnifiedIdentifierBuf::new("Literal"), TypeId::LITERAL_RESTRICTION),
+                        (UnifiedIdentifierBuf::new("Readonly"), TypeId::READONLY_RESTRICTION),
+                        (UnifiedIdentifierBuf::new("Exclusive"), TypeId::EXCLUSIVE_RESTRICTION),
+                        (UnifiedIdentifierBuf::new("Uppercase"), TypeId::STRING_UPPERCASE),
+                        (UnifiedIdentifierBuf::new("Lowercase"), TypeId::STRING_LOWERCASE),
+                        (UnifiedIdentifierBuf::new("Capitalize"), TypeId::STRING_CAPITALIZE),
+                        (UnifiedIdentifierBuf::new("Uncapitalize"), TypeId::STRING_UNCAPITALIZE),
+                        (UnifiedIdentifierBuf::new("NoInfer"), TypeId::NO_INFER),
+                        (UnifiedIdentifierBuf::new("GreaterThan"), TypeId::GREATER_THAN),
+                        (UnifiedIdentifierBuf::new("LessThan"), TypeId::LESS_THAN),
+                        (UnifiedIdentifierBuf::new("MultipleOf"), TypeId::MULTIPLE_OF),
+                        (UnifiedIdentifierBuf::new("NotNotANumber"), TypeId::NUMBER_BUT_NOT_NOT_A_NUMBER),
+                        (UnifiedIdentifierBuf::new("Not"), TypeId::NOT_RESTRICTION),
+                        (UnifiedIdentifierBuf::new("CaseInsensitive"), TypeId::CASE_INSENSITIVE),
+                        (UnifiedIdentifierBuf::new("Infinity"), TypeId::INFINITY),
+                        (UnifiedIdentifierBuf::new("NegativeInfinity"), TypeId::NEG_INFINITY),
+                        (UnifiedIdentifierBuf::new("MinFloat"), TypeId::FLOAT_MIN),
+                        (UnifiedIdentifierBuf::new("MaxFloat"), TypeId::FLOAT_MAX),
+                ]);
 
 		let mut info = LocalInformation::default();
 
@@ -99,7 +100,7 @@ impl RootContext {
 				allow_reregistration: false,
 			};
 			let undefined_id = variable_or_import.get_id();
-			let variables = [("undefined".to_owned(), variable_or_import)];
+                        let variables = [(UnifiedIdentifierBuf::new("undefined"), variable_or_import)];
 			info.variable_current_value.insert(undefined_id, TypeId::UNDEFINED_TYPE);
 			variables
 		};

--- a/checker/src/features/functions.rs
+++ b/checker/src/features/functions.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::hash_map::Entry};
 
 use source_map::{Nullable, SourceId, SpanWithSource};
+use unified_identifier::UnifiedIdentifierBuf;
 
 use crate::{
 	context::{
@@ -57,14 +58,16 @@ pub fn register_expression_function<T: crate::ReadFromFS, A: crate::ASTImplement
 	is_async: bool,
 	is_generator: bool,
 	location: ContextLocation,
-	name: Option<String>,
+        name: Option<UnifiedIdentifierBuf>,
 	function: &impl SynthesisableFunction<A>,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, A>,
 ) -> TypeId {
-	let name = if let Some(name) = name {
-		checking_data.types.new_constant_type(Constant::String(name))
-	} else {
+        let name = if let Some(name) = name {
+                checking_data
+                        .types
+                        .new_constant_type(Constant::String(name.original().to_string()))
+        } else {
 		extract_name(expected, &checking_data.types, environment)
 	};
 	let function_type = synthesise_function(
@@ -89,12 +92,14 @@ pub fn synthesise_hoisted_statement_function<T: crate::ReadFromFS, A: crate::AST
 	is_async: bool,
 	is_generator: bool,
 	location: ContextLocation,
-	name: String,
+        name: UnifiedIdentifierBuf,
 	function: &impl SynthesisableFunction<A>,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, A>,
 ) -> TypeId {
-	let name = checking_data.types.new_constant_type(Constant::String(name));
+        let name = checking_data
+                .types
+                .new_constant_type(Constant::String(name.original().to_string()));
 	let behavior = FunctionRegisterBehavior::StatementFunction {
 		variable_id,
 		is_async,
@@ -131,13 +136,15 @@ pub fn synthesise_declare_statement_function<T: crate::ReadFromFS, A: crate::AST
 	is_async: bool,
 	is_generator: bool,
 	location: ContextLocation,
-	name: String,
+        name: UnifiedIdentifierBuf,
 	internal_marker: Option<InternalFunctionEffect>,
 	function: &impl SynthesisableFunction<A>,
 	environment: &mut Environment,
 	checking_data: &mut CheckingData<T, A>,
 ) -> TypeId {
-	let name = checking_data.types.new_constant_type(Constant::String(name));
+        let name = checking_data
+                .types
+                .new_constant_type(Constant::String(name.original().to_string()));
 	let behavior = FunctionRegisterBehavior::StatementFunction {
 		variable_id,
 		is_async,

--- a/checker/src/features/modules.rs
+++ b/checker/src/features/modules.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use simple_json_parser::{JSONKey, RootJSONValue};
 use source_map::{FileSystem, Span};
+use unified_identifier::UnifiedIdentifierBuf;
 
 /// For imports and exports
 #[derive(Debug)]
@@ -57,10 +58,10 @@ impl<M> SynthesisedModule<M> {
 /// TODO tidy
 #[derive(Clone, Debug, Default, binary_serialize_derive::BinarySerializable)]
 pub struct Exported {
-	pub default: Option<TypeId>,
-	/// Mutability purely for the mutation thingy
-	pub named: Map<String, (VariableId, VariableMutability)>,
-	pub named_types: Map<String, TypeId>,
+        pub default: Option<TypeId>,
+        /// Mutability purely for the mutation thingy
+        pub named: Map<UnifiedIdentifierBuf, (VariableId, VariableMutability)>,
+        pub named_types: Map<UnifiedIdentifierBuf, TypeId>,
 }
 
 pub type ExportedVariable = (VariableId, VariableMutability);
@@ -156,7 +157,7 @@ pub fn import_items<
 					import_specified_at: position.with_source(current_source),
 				};
 				environment.info.variable_current_value.insert(id, *item);
-				let existing = environment.variables.insert(default_name.to_owned(), v);
+                                let existing = environment.variables.insert(UnifiedIdentifierBuf::new(default_name), v);
 				if let Some(existing) = existing {
 					checking_data.diagnostics_container.add_error(
 						crate::diagnostics::TypeCheckError::DuplicateImportName {
@@ -258,8 +259,8 @@ pub fn import_items<
 								.position
 								.with_source(environment.get_source()),
 						};
-						crate::utilities::notify!("{:?}", part.r#as.to_owned());
-						let existing = environment.variables.insert(part.r#as.to_owned(), v);
+                                                crate::utilities::notify!("{:?}", part.r#as);
+                                                let existing = environment.variables.insert(part.r#as.clone(), v);
 						if let Some(existing) = existing {
 							checking_data.diagnostics_container.add_error(
 								crate::diagnostics::TypeCheckError::DuplicateImportName {
@@ -286,14 +287,14 @@ pub fn import_items<
 							if let Scope::Module { ref mut exported, .. } =
 								environment.context_type.scope
 							{
-								exported.named.insert(part.r#as.to_owned(), (variable, mutability));
+                                                                exported.named.insert(part.r#as.clone(), (variable, mutability));
 							}
 						}
 					}
 
 					// add type to scope
 					if let Some(ty) = exported_type {
-						let existing = environment.named_types.insert(part.r#as.to_owned(), ty);
+                                                let existing = environment.named_types.insert(part.r#as.clone(), ty);
 						assert!(existing.is_none(), "TODO exception");
 					}
 				} else {

--- a/checker/src/lib.rs
+++ b/checker/src/lib.rs
@@ -16,10 +16,11 @@ pub mod utilities;
 pub mod synthesis;
 
 use std::{
-	collections::{HashMap, HashSet},
-	path::{Path, PathBuf},
-	time::Duration,
+        collections::{HashMap, HashSet},
+        path::{Path, PathBuf},
+        time::Duration,
 };
+use unified_identifier::UnifiedIdentifierBuf;
 
 use context::{
 	information::{LocalInformation, ModuleInformation},
@@ -604,8 +605,8 @@ const CACHE_MARKER: &[u8] = b"ezno-cache-file";
 
 #[derive(binary_serialize_derive::BinarySerializable)]
 pub(crate) struct Cache {
-	pub(crate) variables: HashMap<String, features::variables::VariableOrImport>,
-	pub(crate) named_types: HashMap<String, TypeId>,
+        pub(crate) variables: HashMap<UnifiedIdentifierBuf, features::variables::VariableOrImport>,
+        pub(crate) named_types: HashMap<UnifiedIdentifierBuf, TypeId>,
 	pub(crate) info: LocalInformation,
 	pub(crate) types: TypeStore,
 	// /// Retains position information

--- a/checker/src/synthesis/statements.rs
+++ b/checker/src/synthesis/statements.rs
@@ -16,12 +16,13 @@ use crate::{
 
 use parser::{expressions::MultipleExpression, ASTNode, BlockOrSingleStatement, Statement};
 use std::collections::HashMap;
+use unified_identifier::UnifiedIdentifierBuf;
 
-pub type ExportedItems = HashMap<String, crate::features::variables::VariableOrImport>;
+pub type ExportedItems = HashMap<UnifiedIdentifierBuf, crate::features::variables::VariableOrImport>;
 pub type ReturnResult = Option<TypeId>;
 
 pub struct StatementInformation {
-	label: Option<String>,
+        label: Option<UnifiedIdentifierBuf>,
 }
 
 pub(super) fn synthesise_statement<T: crate::ReadFromFS>(

--- a/unified_identifier/Cargo.toml
+++ b/unified_identifier/Cargo.toml
@@ -18,11 +18,6 @@ source-map = { version = "0.15", features = [
 ] }
 self-rust-tokenize = { version = "0.3", optional = true }
 checker_utility_types = { path = "../checker_utility_types" }
-
-source-map = { version = "0.15", features = [
-  "serde-serialize",
-  "self-rust-tokenize",
-] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 once_cell = "1.21.3"
 

--- a/unified_identifier/src/lib.rs
+++ b/unified_identifier/src/lib.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{borrow::Cow, fmt, hash::{Hash, Hasher}, ops::Deref};
 use once_cell::sync::OnceCell;
 use std::borrow::Borrow;
+use source_map::SourceId;
 
 /* -------------------------------------------------------------------------
  *  Normalised data representation (borrowed)
@@ -38,10 +39,15 @@ impl checker_utility_types::BinarySerializable for UnifiedIdentifierBuf {
 		buf.extend_from_slice(self.as_bytes());
 	}
 
-	fn deserialize<I: Iterator<Item = u8>>(iter: &mut I, _source: SourceId) -> Self {
-		let len = iter.next().unwrap();
-		iter.by_ref().take(len as usize).map(|v| v as char).collect::<String>()
-	}
+        fn deserialize<I: Iterator<Item = u8>>(iter: &mut I, _source: SourceId) -> Self {
+                let len = iter.next().unwrap();
+                let string = iter
+                        .by_ref()
+                        .take(len as usize)
+                        .map(|v| v as char)
+                        .collect::<String>();
+                Self::new(string)
+        }
 }
 
 impl Borrow<str> for UnifiedIdentifierBuf {


### PR DESCRIPTION
## Summary
- remove duplicate dependencies in unified_identifier crate
- implement `SourceId` support in UnifiedIdentifierBuf deserialisation
- start refactoring checker to use `UnifiedIdentifierBuf` for names
- adjust various contexts, functions and modules to accept `UnifiedIdentifierBuf`

## Testing
- `cargo check -q` *(fails: could not compile `ezno-checker`)*

------
https://chatgpt.com/codex/tasks/task_e_687f47e13bbc8328b51e13cb17681b48